### PR TITLE
Fix pretty-print program incorrectly parsing backslashes

### DIFF
--- a/assignment2/parser-subset-tests/ok-fuzzer/13.jpl.expected
+++ b/assignment2/parser-subset-tests/ok-fuzzer/13.jpl.expected
@@ -1,4 +1,4 @@
-(WriteImageCmd (VarExpr T) "\u0006")
+(WriteImageCmd (VarExpr T) "\6")
 (WriteImageCmd (FloatExpr 29) "$m")
 (StmtCmd (ReturnStmt (CallExpr P)))
 (PrintCmd "")

--- a/assignment2/parser-subset-tests/pp.rkt
+++ b/assignment2/parser-subset-tests/pp.rkt
@@ -1,3 +1,11 @@
 #lang racket
-(for ([line (in-port read)] #:break (equal? line 'Compilation))
-  (pretty-print line (current-output-port) 1))
+
+; Read stdin as string > escape backslashes > parse as s-expressions > pretty print as
+; string > remove backslash escapes
+(for ([line (in-port read-line)] #:break (string-prefix? line "Compilation"))
+     (define op (open-output-string))
+     ; Use pretty-print for quote-depth functionality.
+     ; Escape backslashes so read interprets them as literal backslashes.
+     (pretty-print (read (open-input-string (string-replace line "\\" "\\\\"))) op 1)
+     ; Remove the escapes from before.
+     (display (string-replace (get-output-string op) "\\\\" "\\")))

--- a/assignment2/pp.rkt
+++ b/assignment2/pp.rkt
@@ -1,7 +1,11 @@
 #lang racket
 
-;; make an executable version of this like so:
-;; raco exe pp.rkt
-
-(for ([line (in-port read)] #:break (equal? line 'Compilation))
-  (pretty-print line (current-output-port) 1))
+; Read stdin as string > escape backslashes > parse as s-expressions > pretty print as
+; string > remove backslash escapes
+(for ([line (in-port read-line)] #:break (string-prefix? line "Compilation"))
+     (define op (open-output-string))
+     ; Use pretty-print for quote-depth functionality.
+     ; Escape backslashes so read interprets them as literal backslashes.
+     (pretty-print (read (open-input-string (string-replace line "\\" "\\\\"))) op 1)
+     ; Remove the escapes from before.
+     (display (string-replace (get-output-string op) "\\\\" "\\")))


### PR DESCRIPTION
pp.rkt would incorrectly interpret backslashes in strings as escape sequences, e.g.:
```
emersonf on lab1-32 in cs4470 on master
❯ ./main.py -p jpl/assignment2/parser-subset-tests/ok-fuzzer/13.jpl | racket jpl/assignment2/parser-subset-tests/pp.rkt
(WriteImageCmd (VarExpr T) "\u0006")
(WriteImageCmd (FloatExpr 29) "$m")
(StmtCmd (ReturnStmt (CallExpr P)))
(PrintCmd "")
(StmtCmd (AssertStmt (FloatExpr 841) ""))
(ReadImageCmd "Vx86H" (VarArgument Z))
(ReadImageCmd "" (VarArgument g))
(PrintCmd "")
(TimeCmd (ShowCmd (VarExpr S8p.5U.2m_4V_2g.1a_)))
(ShowCmd (VarExpr R))
(PrintCmd "1P")
(PrintCmd "z")
```

This fix corrects that:
```
emersonf on lab1-32 in cs4470 on master
❯ ./main.py -p jpl/assignment2/parser-subset-tests/ok-fuzzer/13.jpl | racket jpl/assignment2/parser-subset-tests/pp.rkt
(WriteImageCmd (VarExpr T) "\6")
(WriteImageCmd (FloatExpr 29) "$m")
(StmtCmd (ReturnStmt (CallExpr P)))
(PrintCmd "")
(StmtCmd (AssertStmt (FloatExpr 841) ""))
(ReadImageCmd "Vx86H" (VarArgument Z))
(ReadImageCmd "" (VarArgument g))
(PrintCmd "")
(TimeCmd (ShowCmd (VarExpr S8p.5U.2m_4V_2g.1a_)))
(ShowCmd (VarExpr R))
(PrintCmd "1P")
(PrintCmd "z")
```

Verifying I get the same result with `test-subset-parser` after changes:
```
emersonf on lab1-32 in cs4470 on master
❯ ./jpl/assignment2/test-subset-parser
/home/emersonf/School/cs4470/jpl/assignment2/parser-subset-tests/ok/001.jpl : expect = 0, got = 0
/home/emersonf/School/cs4470/jpl/assignment2/parser-subset-tests/ok/002.jpl : expect = 0, got = 0
/home/emersonf/School/cs4470/jpl/assignment2/parser-subset-tests/ok/003.jpl : expect = 0, got = 0
...
/home/emersonf/School/cs4470/jpl/assignment2/parser-subset-tests/ok-fuzzer/98.jpl : expect = 0, got = 0
/home/emersonf/School/cs4470/jpl/assignment2/parser-subset-tests/ok-fuzzer/99.jpl : expect = 0, got = 0
make: *** [Makefile:9: run] Error 1
/home/emersonf/School/cs4470/jpl/assignment2/parser-subset-tests/fail-fuzzer1/1.jpl : expect = 1, got = 1
make: *** [Makefile:9: run] Error 1
/home/emersonf/School/cs4470/jpl/assignment2/parser-subset-tests/fail-fuzzer1/10.jpl : expect = 1, got = 1
make: *** [Makefile:9: run] Error 1
/home/emersonf/School/cs4470/jpl/assignment2/parser-subset-tests/fail-fuzzer1/100.jpl : expect = 1, got = 1
make: *** [Makefile:9: run] Error 1
/home/emersonf/School/cs4470/jpl/assignment2/parser-subset-tests/fail-fuzzer1/101.jpl : expect = 1, got = 1
...
make: *** [Makefile:9: run] Error 1
/home/emersonf/School/cs4470/jpl/assignment2/parser-subset-tests/fail-fuzzer3/99.jpl : expect = 1, got = 1

All tests pass.
```
